### PR TITLE
Tweak suggested install rules

### DIFF
--- a/tpt/ppatrigger/templates/ppatrigger/help.html
+++ b/tpt/ppatrigger/templates/ppatrigger/help.html
@@ -16,11 +16,11 @@
           </p>
 <pre>
 before_install:
-  - yes | sudo add-apt-repository ppa:hansjorg/rust
-  - yes | sudo add-apt-repository ppa:cmrx64/cargo
-  - sudo apt-get update
+  - sudo add-apt-repository --yes ppa:hansjorg/rust
+  - sudo add-apt-repository --yes ppa:cmrx64/cargo
+  - sudo apt-get update -qq
 install:
-  - sudo apt-get install rust-nightly cargo
+  - sudo apt-get install -qq rust-nightly cargo
 script:
   - cargo build
 </pre>


### PR DESCRIPTION
It really bugged me that the suggested rules were using pipes instead of builtin "yes, really do it" support.
