### PR TITLE
Add cargo-doc support

### DIFF
--- a/tpt/ppatrigger/templates/ppatrigger/put_artifacts_script.txt
+++ b/tpt/ppatrigger/templates/ppatrigger/put_artifacts_script.txt
@@ -2,7 +2,12 @@
 
 echo "Rust-ci putdocs starting"
 
-DOCROOT=doc
+if [ -d doc ]; then
+    DOCROOT=doc
+elif [ -d target/doc ]; then
+    DOCROOT=target/doc
+fi
+
 export AWS_DEFAULT_REGION=eu-west-1
 export AWS_ACCESS_KEY_ID={{ s3_access_key_id }}
 export AWS_SECRET_ACCESS_KEY={{ s3_secret_access_key }}


### PR DESCRIPTION
This adds support for the `cargo-doc` command which creates the documentation in `target/doc`.
